### PR TITLE
feat : JWT 인증 기반 회원 로그아웃 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis' // redis
 	// JWT 최신 버전 (0.11.5)으로 교체
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/woong/daangnmarket/config/RedisConfig.java
+++ b/src/main/java/com/woong/daangnmarket/config/RedisConfig.java
@@ -1,0 +1,27 @@
+package com.woong.daangnmarket.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    @Primary // 👈@Primary가 붙은 빈을 우선 주입합니다
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(factory);
+
+        // 문자열 형식으로 Redis 데이터 직렬화
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/woong/daangnmarket/config/SecurityConfig.java
+++ b/src/main/java/com/woong/daangnmarket/config/SecurityConfig.java
@@ -1,16 +1,27 @@
 package com.woong.daangnmarket.config;
 
+import com.woong.daangnmarket.jwt.JwtAuthenticationFilter;
+import com.woong.daangnmarket.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier; //
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import static org.springframework.security.config.Customizer.withDefaults;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+
+    private final RedisTemplate<String, String> redisTemplate; // RedisTemplate 주입
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -19,16 +30,18 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-                .csrf(csrf -> csrf.disable())  // CSRF 비활성화
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/members/**").permitAll()
-                        .anyRequest().authenticated()
-                )
-                .formLogin(form -> form.disable()); // 비활성화
+        JwtAuthenticationFilter jwtFilter = new JwtAuthenticationFilter(jwtTokenProvider, redisTemplate);
 
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/members/**", "/api/login", "/api/signup" , "/api/logout").permitAll()
+                        .anyRequest().authenticated())
+                .formLogin(form -> form.disable())
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
-    }
-
+}

--- a/src/main/java/com/woong/daangnmarket/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/woong/daangnmarket/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,68 @@
+package com.woong.daangnmarket.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String requestURI = request.getRequestURI();
+        log.info("[JwtAuthenticationFilter] 요청 URI: {}", requestURI);
+
+        // 로그아웃 경로는 필터 통과시키기 (블랙리스트 검사 생략)
+        if (requestURI.equals("/api/logout")) {
+            log.info("[JwtAuthenticationFilter] 로그아웃 경로, 필터 통과");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = resolveToken(request);
+        log.info("[JwtAuthenticationFilter] 추출된 토큰: {}", token);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            log.info("[JwtAuthenticationFilter] 토큰 유효성 검사 통과");
+
+            // 블랙리스트에 등록된 토큰이면 거부
+            if (redisTemplate.hasKey(token)) {
+                log.warn("[JwtAuthenticationFilter] 블랙리스트 토큰 요청: {}", token);
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
+
+            // 인증 객체 설정
+            Authentication auth = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            log.info("[JwtAuthenticationFilter] 인증 정보 설정 완료: {}", auth.getName());
+        } else {
+            log.info("[JwtAuthenticationFilter] 토큰이 없거나 유효하지 않음");
+        }
+
+        // 다음 필터로 진행
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        return (bearer != null && bearer.startsWith("Bearer ")) ? bearer.substring(7) : null;
+    }
+}
+

--- a/src/main/java/com/woong/daangnmarket/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/woong/daangnmarket/jwt/JwtTokenProvider.java
@@ -1,12 +1,15 @@
 package com.woong.daangnmarket.jwt;
 
-import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
+import java.util.Collections;
 import java.util.Date;
 
 @Component
@@ -30,5 +33,38 @@ public class JwtTokenProvider {
                 .setExpiration(expiry)
                 .signWith(key)
                 .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public String getEmail(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public long getExpiration(String token) {
+        Date expiration = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
+        return expiration.getTime() - System.currentTimeMillis();
+    }
+
+    public Authentication getAuthentication(String token) {
+        String email = getEmail(token);
+        return new UsernamePasswordAuthenticationToken(email, null, Collections.emptyList());
     }
 }

--- a/src/main/java/com/woong/daangnmarket/member/controller/LogoutController.java
+++ b/src/main/java/com/woong/daangnmarket/member/controller/LogoutController.java
@@ -1,0 +1,49 @@
+package com.woong.daangnmarket.member.controller;
+
+import com.woong.daangnmarket.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.concurrent.TimeUnit;
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/logout")
+public class LogoutController {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LogoutController.class);
+
+    @PostMapping
+    public ResponseEntity<String> logout(@RequestHeader("Authorization") String authHeader) {
+        log.info("[LogoutController] 로그아웃 요청 받음, Authorization 헤더: {}", authHeader);
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            log.warn("[LogoutController] 잘못된 Authorization 헤더");
+            return ResponseEntity.badRequest().body("잘못된 Authorization 헤더입니다.");
+        }
+
+        String token = authHeader.substring(7); // Bearer 제거
+        log.info("[LogoutController] 토큰 추출됨: {}", token);
+
+        if (!jwtTokenProvider.validateToken(token)) {
+            log.warn("[LogoutController] 유효하지 않은 토큰");
+            return ResponseEntity.badRequest().body("유효하지 않은 토큰입니다.");
+        }
+
+        String email = jwtTokenProvider.getEmail(token);
+        long expiration = jwtTokenProvider.getExpiration(token);
+
+        log.info("[LogoutController] 블랙리스트에 토큰 저장 - email: {}, 만료시간(ms): {}", email, expiration);
+
+        // 블랙리스트 등록
+        redisTemplate.opsForValue().set(token, email, expiration, TimeUnit.MILLISECONDS);
+
+        log.info("[LogoutController] 로그아웃 처리 완료 - 토큰: {}, 이메일: {}", token, email);
+
+        return ResponseEntity.ok("로그아웃 성공");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,4 +23,6 @@ spring:
 jwt:
   secret: myVerySecretKeyThatIsAtLeast32BytesLong1234!
 
-
+redis:
+    host: localhost
+    port: 6379


### PR DESCRIPTION
## 📄기능
JWT 로그아웃 기능 구현 (토큰 블랙리스트 등록 방식)

## ✔작업 상세 내용
- [ ]  /api/logout 로그아웃 API 구현

- [ ]  JWT 유효성 검사 후 Redis에 토큰을 블랙리스트로 저장

- [ ] JWT 인증 필터(JwtAuthenticationFilter)에서 블랙리스트 체크

- [ ]  Redis 설정 파일(RedisConfig) 작성 및 적용

- [ ] SecurityConfig에 필터 등록 및 /api/logout 경로 허용 추가

- [ ]  Postman을 이용한 로그아웃 요청 테스트 완료
