### PR TITLE
feat : 회원가입 로그인 테스트코드

### DIFF
--- a/src/main/java/com/woong/daangnmarket/member/dto/LoginRequest.java
+++ b/src/main/java/com/woong/daangnmarket/member/dto/LoginRequest.java
@@ -2,13 +2,16 @@ package com.woong.daangnmarket.member.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@AllArgsConstructor // 기본 생성자 자동 생성 (파라미터 없는 생성자)
+@NoArgsConstructor // 모든 필드를 파라미터로 받는 생성자 자동 생성
 public class LoginRequest {
-
     @NotBlank(message = "이메일은 필수입니다.")
     @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
@@ -16,3 +19,6 @@ public class LoginRequest {
     @NotBlank(message = "비밀번호는 필수입니다.")
     private String password;
 }
+
+
+

--- a/src/test/java/com/woong/daangnmarket/member/MemberServiceTest.java
+++ b/src/test/java/com/woong/daangnmarket/member/MemberServiceTest.java
@@ -1,0 +1,120 @@
+
+
+// 1. MemberService 단위 테스트
+package com.woong.daangnmarket.member;
+
+import com.woong.daangnmarket.jwt.JwtTokenProvider;
+import com.woong.daangnmarket.member.domain.Member;
+import com.woong.daangnmarket.member.domain.repository.MemberRepository;
+import com.woong.daangnmarket.member.dto.LoginRequest;
+import com.woong.daangnmarket.member.dto.SignUpRequest;
+import com.woong.daangnmarket.member.exception.EmailAlreadyExistsException;
+import com.woong.daangnmarket.member.service.MemberService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    private SignUpRequest makeSignUpRequest() {
+        SignUpRequest request = new SignUpRequest();
+        setField(request, "email", "test@example.com");
+        setField(request, "password", "1234abcd");
+        setField(request, "nickname", "테스터");
+        return request;
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            var field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void 회원가입_성공() {
+        SignUpRequest request = makeSignUpRequest();
+
+        when(memberRepository.existsByEmail(request.getEmail())).thenReturn(false);
+        when(passwordEncoder.encode(request.getPassword())).thenReturn("encodedPassword");
+        when(memberRepository.save(any(Member.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        memberService.signUp(request);
+
+        verify(memberRepository).save(any(Member.class));
+    }
+
+    @Test
+    void 회원가입_실패_중복이메일() {
+        SignUpRequest request = makeSignUpRequest();
+
+        when(memberRepository.existsByEmail(request.getEmail())).thenReturn(true);
+
+        assertThrows(EmailAlreadyExistsException.class, () -> memberService.signUp(request));
+    }
+
+    @Test
+    void 로그인_성공() {
+        LoginRequest loginRequest = new LoginRequest("test@example.com", "1234abcd");
+        Member member = Member.builder()
+                .email("test@example.com")
+                .password("encodedPassword")
+                .build();
+
+        when(memberRepository.findByEmail(loginRequest.getEmail())).thenReturn(Optional.of(member));
+        when(passwordEncoder.matches(loginRequest.getPassword(), member.getPassword())).thenReturn(true);
+        when(jwtTokenProvider.createToken(member.getEmail())).thenReturn("jwt-token");
+
+        var response = memberService.login(loginRequest);
+
+        assertEquals("jwt-token", response.getToken());
+
+    }
+
+    @Test
+    void 로그인_실패_이메일없음() {
+        LoginRequest loginRequest = new LoginRequest("notfound@example.com", "1234abcd");
+
+        when(memberRepository.findByEmail(loginRequest.getEmail())).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class, () -> memberService.login(loginRequest));
+    }
+
+    @Test
+    void 로그인_실패_비밀번호불일치() {
+        LoginRequest loginRequest = new LoginRequest("test@example.com", "wrongpass");
+        Member member = Member.builder()
+                .email("test@example.com")
+                .password("encodedPassword")
+                .build();
+
+        when(memberRepository.findByEmail(loginRequest.getEmail())).thenReturn(Optional.of(member));
+        when(passwordEncoder.matches(loginRequest.getPassword(), member.getPassword())).thenReturn(false);
+
+        assertThrows(IllegalArgumentException.class, () -> memberService.login(loginRequest));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #5 

## 📝작업 내용

>  1. MemberService 단위 테스트 작성

회원가입 기능 테스트

성공 케이스: 정상적으로 회원가입 시 데이터 저장 확인

실패 케이스: 중복 이메일일 경우 예외 처리 확인

로그인 기능 테스트

성공 케이스: 올바른 이메일과 비밀번호로 JWT 토큰 정상 발급 확인

실패 케이스: 이메일 미존재 시 예외 처리

실패 케이스: 비밀번호 불일치 시 예외 처리



> 2. DTO 클래스 보완

LoginRequest 클래스에 기본 생성자(@NoArgsConstructor)와 모든 필드를 받는 생성자(@AllArgsConstructor) 추가

테스트 코드에서 편리하게 인스턴스 생성 가능하도록 수정

> 3. 테스트 환경 설정

Mockito를 이용한 Mock 객체 생성 및 주입(@Mock, @InjectMocks)

MockitoExtension으로 JUnit5 환경에서 Mockito 지원

필드 주입(setField) 유틸 메서드 구현하여 리플렉션으로 테스트용 데이터 주입

### 스크린샷 (선택)

