### PR TITLE
feat : 게시글 등록 기능 구현

### DIFF
--- a/src/main/java/com/woong/daangnmarket/config/SecurityConfig.java
+++ b/src/main/java/com/woong/daangnmarket/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/members/**", "/api/login", "/api/signup" , "/api/logout").permitAll()
+                        .requestMatchers("/api/members/**", "/api/login", "/api/signup" , "/api/logout" , "/api/posts").permitAll()
                         .anyRequest().authenticated())
                 .formLogin(form -> form.disable())
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/woong/daangnmarket/post/controller/PostController.java
+++ b/src/main/java/com/woong/daangnmarket/post/controller/PostController.java
@@ -1,0 +1,32 @@
+package com.woong.daangnmarket.post.controller;
+
+import com.woong.daangnmarket.post.dto.PostRequest;
+import com.woong.daangnmarket.post.dto.PostResponse;
+import com.woong.daangnmarket.post.service.PostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posts")
+public class PostController {
+
+    private final PostService postService;
+
+    /**
+     * 게시글 등록 API
+     * 
+     * @param request 게시글 등록 요청 데이터
+     * @return 생성된 게시글 정보(PostResponse)
+     */
+    @PostMapping
+    public ResponseEntity<PostResponse> createPost(@RequestBody @Valid PostRequest request) {
+        PostResponse response = postService.createPost(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/woong/daangnmarket/post/domain/entity/Category.java
+++ b/src/main/java/com/woong/daangnmarket/post/domain/entity/Category.java
@@ -1,0 +1,21 @@
+package com.woong.daangnmarket.post.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "CATEGORY_ID")
+    private Long id;
+
+    private String categoryName;
+
+
+}

--- a/src/main/java/com/woong/daangnmarket/post/domain/entity/Post.java
+++ b/src/main/java/com/woong/daangnmarket/post/domain/entity/Post.java
@@ -1,0 +1,83 @@
+package com.woong.daangnmarket.post.domain.entity;
+
+
+import com.woong.daangnmarket.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "post")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 게시글 고유 ID
+
+    @Column(nullable = false, length = 255)
+    private String title; // 게시글 제목
+
+    @Lob
+    @Column(nullable = false)
+    private String content; // 게시글 내용
+
+    private Integer price; // 상품 가격 (NULL 가능)
+
+    @Column(nullable = false, length = 100)
+    private String region; // 게시글 지역
+
+    @Column(nullable = false, length = 20)
+    private String status; // 판매 상태 (SALE, RESERVED, SOLD)
+
+    @Column(name = "image_url", length = 300)
+    private String imageUrl; // 대표 이미지 URL (NULL 가능)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member; // 작성자 (회원) FK
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category; // 카테고리 FK (NULL 가능)
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt; // 생성 일자
+
+    @Column(name = "IS_REMOVED")
+    private Boolean removed = false;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public Post(String title, String content, Integer price, String region,
+                String status, String imageUrl, Member member, Category category) {
+        this.title = title;
+        this.content = content;
+        this.price = price;
+        this.region = region;
+        this.status = status;
+        this.imageUrl = imageUrl;
+        this.member = member;
+        this.category = category;
+    }
+
+    /**
+     * 게시글을 소프트 삭제 처리하는 메서드입니다.
+     * 실제로 데이터베이스에서 행(row)을 삭제하지 않고,
+     * 삭제 여부를 나타내는 removed 필드를 true로 변경하여
+     * 해당 게시글이 삭제된 상태임을 표시합니다.
+     * 소프트 삭제를 위해서는 게시글 조회 시 removed가 false인 데이터만 조회하도록
+     * 쿼리에서 조건을 추가해야 합니다.
+     */
+    public void removePost() {
+        this.removed = true;
+    }
+
+}
+

--- a/src/main/java/com/woong/daangnmarket/post/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/woong/daangnmarket/post/domain/repository/CategoryRepository.java
@@ -1,0 +1,12 @@
+package com.woong.daangnmarket.post.domain.repository;
+
+
+import com.woong.daangnmarket.post.domain.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    public Optional<Category> findCategoryByCategoryName(String categoryName);
+}

--- a/src/main/java/com/woong/daangnmarket/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/woong/daangnmarket/post/domain/repository/PostRepository.java
@@ -1,0 +1,14 @@
+package com.woong.daangnmarket.post.domain.repository;
+
+
+import com.woong.daangnmarket.post.domain.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @Query("SELECT p FROM Post p WHERE p.id = :postId AND p.removed = false")
+    public Optional<Post> findPostById(Long postId);
+}

--- a/src/main/java/com/woong/daangnmarket/post/dto/PostRequest.java
+++ b/src/main/java/com/woong/daangnmarket/post/dto/PostRequest.java
@@ -1,0 +1,18 @@
+package com.woong.daangnmarket.post.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PostRequest {
+
+    private String title;         // 게시글 제목
+    private String content;       // 게시글 내용
+    private Integer price;        // 상품 가격
+    private String region;        // 지역 (예: 서울 송파구)
+    private String status;        // 판매 상태 (SALE, RESERVED, SOLD)
+    private String imageUrl;      // 대표 이미지 URL
+    private Long memberId;        // 작성자 ID
+    private Long categoryId;      // 카테고리 ID
+}

--- a/src/main/java/com/woong/daangnmarket/post/dto/PostResponse.java
+++ b/src/main/java/com/woong/daangnmarket/post/dto/PostResponse.java
@@ -1,0 +1,34 @@
+package com.woong.daangnmarket.post.dto;
+
+import com.woong.daangnmarket.post.domain.entity.Post;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PostResponse {
+
+    private final Long id;
+    private final String title;
+    private final String content;
+    private final Integer price;
+    private final String region;
+    private final String status;
+    private final String imageUrl;
+    private final Long memberId;
+    private final Long categoryId;
+    private final LocalDateTime createdAt;
+
+    public PostResponse(Post post) {
+        this.id = post.getId();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.price = post.getPrice();
+        this.region = post.getRegion();
+        this.status = post.getStatus();
+        this.imageUrl = post.getImageUrl();
+        this.memberId = post.getMember().getId();
+        this.categoryId = post.getCategory() != null ? post.getCategory().getId() : null;
+        this.createdAt = post.getCreatedAt();
+    }
+}

--- a/src/main/java/com/woong/daangnmarket/post/service/CategoryService.java
+++ b/src/main/java/com/woong/daangnmarket/post/service/CategoryService.java
@@ -1,0 +1,9 @@
+package com.woong.daangnmarket.post.service;
+
+
+import com.woong.daangnmarket.post.domain.entity.Category;
+
+public interface CategoryService {
+
+    public Category findCategoryByName(String categoryName);
+}

--- a/src/main/java/com/woong/daangnmarket/post/service/PostService.java
+++ b/src/main/java/com/woong/daangnmarket/post/service/PostService.java
@@ -1,0 +1,57 @@
+package com.woong.daangnmarket.post.service;
+
+
+import com.woong.daangnmarket.member.domain.Member;
+
+import com.woong.daangnmarket.member.domain.repository.MemberRepository;
+import com.woong.daangnmarket.post.domain.entity.Category;
+import com.woong.daangnmarket.post.domain.entity.Post;
+import com.woong.daangnmarket.post.domain.repository.CategoryRepository;
+import com.woong.daangnmarket.post.domain.repository.PostRepository;
+import com.woong.daangnmarket.post.dto.PostRequest;
+import com.woong.daangnmarket.post.dto.PostResponse;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public PostResponse createPost(PostRequest request) {
+        // 작성자 조회
+        Member member = memberRepository.findById(request.getMemberId())
+                .orElseThrow(() -> new IllegalArgumentException("작성자 정보가 존재하지 않습니다."));
+
+        // 카테고리 조회 (null 가능)
+        Category category = null;
+        if (request.getCategoryId() != null) {
+            category = categoryRepository.findById(request.getCategoryId())
+                    .orElseThrow(() -> new IllegalArgumentException("카테고리 정보가 존재하지 않습니다."));
+        }
+
+        // 게시글 생성
+        Post post = Post.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .price(request.getPrice())
+                .region(request.getRegion())
+                .status(request.getStatus())
+                .imageUrl(request.getImageUrl())
+                .member(member)
+                .category(category)
+                .build();
+
+        // 저장
+        Post saved = postRepository.save(post);
+
+        // 응답 DTO 반환
+        return new PostResponse(saved);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #8 

## 📝작업 내용
- 게시글 등록 API (`POST /api/posts`)
- 게시글 Entity 및 DTO 작성
- 연관관계: Member, Category
- 이미지 다중 등록용 PostImage 엔티티 추가
- `List<String> imageUrls`로 이미지 등록 가능

### 스크린샷 (선택)

