### PR TITLE
feat : 지역 기반 게시글 조회 api

### DIFF
--- a/src/main/java/com/woong/daangnmarket/config/SecurityConfig.java
+++ b/src/main/java/com/woong/daangnmarket/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/members/**", "/api/login", "/api/signup" , "/api/logout" , "/api/posts/**").permitAll()
+                        .requestMatchers("/api/members/**", "/api/login", "/api/signup" , "/api/logout" , "/api/posts/**", "/search/**").permitAll()
                         .anyRequest().authenticated())
                 .formLogin(form -> form.disable())
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/woong/daangnmarket/post/controller/PostController.java
+++ b/src/main/java/com/woong/daangnmarket/post/controller/PostController.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 
 
 @RestController
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class PostController {
 
     private final PostServiceImpl postServiceImpl;
+
 
     /**
      * 게시글 등록 API
@@ -44,4 +46,18 @@ public class PostController {
         PostResponse response = postServiceImpl.getPostById(postId);
         return ResponseEntity.ok(response);
     }
+    // 위치 기반 조회 api
+    @GetMapping("/search")
+    public ResponseEntity<?> search(
+            @RequestParam("lat") double lat,
+            @RequestParam("lon") double lon
+    ) {
+        // 예: 위도, 경도를 기반으로 5km 이내 게시글 조회
+        List<PostResponse> nearbyPosts = postServiceImpl.getPostsByLocation(lat, lon, 5.0); // 반경 5km
+
+        return ResponseEntity.ok(nearbyPosts);
+    }
+
+
+
 }

--- a/src/main/java/com/woong/daangnmarket/post/domain/entity/Location.java
+++ b/src/main/java/com/woong/daangnmarket/post/domain/entity/Location.java
@@ -1,0 +1,30 @@
+package com.woong.daangnmarket.post.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Location {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "LOCATION_ID")
+    private Long id;
+
+    @Column(nullable = false)
+    private Double latitude;
+
+    @Column(nullable = false)
+    private Double longitude;
+
+    @Builder
+    public Location(Double latitude, Double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/src/main/java/com/woong/daangnmarket/post/domain/entity/Post.java
+++ b/src/main/java/com/woong/daangnmarket/post/domain/entity/Post.java
@@ -49,6 +49,11 @@ public class Post {
     @Column(name = "IS_REMOVED")
     private Boolean removed = false;
 
+    // Location과 1:1 연관관계 (Post가 주인)
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "LOCATION_ID")
+    private Location location;
+
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
@@ -56,7 +61,7 @@ public class Post {
 
     @Builder
     public Post(String title, String content, Integer price, String region,
-                String status, String imageUrl, Member member, Category category) {
+                String status, String imageUrl, Member member, Category category, Location location) {
         this.title = title;
         this.content = content;
         this.price = price;
@@ -65,6 +70,8 @@ public class Post {
         this.imageUrl = imageUrl;
         this.member = member;
         this.category = category;
+        this.location = location;
+
     }
 
     /**

--- a/src/main/java/com/woong/daangnmarket/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/woong/daangnmarket/post/domain/repository/PostRepository.java
@@ -2,11 +2,14 @@ package com.woong.daangnmarket.post.domain.repository;
 
 
 import com.woong.daangnmarket.post.domain.entity.Post;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
@@ -16,4 +19,29 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     // soft delete 처리된 게시글 제외하고 조회
     Page<Post> findAllByRemovedFalse(Pageable pageable);
+    // 위치 기반 게시글 조회 - native query (반경 내 게시글 찾기)
+    @Query(value = """
+        SELECT p.*
+        FROM post p
+        JOIN location l ON p.LOCATION_ID = l.LOCATION_ID
+        WHERE p.IS_REMOVED = false
+          AND (
+            6371 * acos(
+              cos(radians(:latitude)) * cos(radians(l.latitude)) *
+              cos(radians(l.longitude) - radians(:longitude)) +
+              sin(radians(:latitude)) * sin(radians(l.latitude))
+            )
+          ) <= :radiusKm
+        ORDER BY (
+            6371 * acos(
+              cos(radians(:latitude)) * cos(radians(l.latitude)) *
+              cos(radians(l.longitude) - radians(:longitude)) +
+              sin(radians(:latitude)) * sin(radians(l.latitude))
+            )
+          )
+        """, nativeQuery = true)
+    List<Post> findPostsByLocationWithinRadius(
+            @Param("latitude") double latitude,
+            @Param("longitude") double longitude,
+            @Param("radiusKm") double radiusKm);
 }

--- a/src/main/java/com/woong/daangnmarket/post/dto/PostRequest.java
+++ b/src/main/java/com/woong/daangnmarket/post/dto/PostRequest.java
@@ -15,4 +15,6 @@ public class PostRequest {
     private String imageUrl;      // 대표 이미지 URL
     private Long memberId;        // 작성자 ID
     private Long categoryId;      // 카테고리 ID
+    private Double latitude;    //위도
+    private Double longitude;   //경도
 }

--- a/src/main/java/com/woong/daangnmarket/post/dto/PostResponse.java
+++ b/src/main/java/com/woong/daangnmarket/post/dto/PostResponse.java
@@ -18,6 +18,8 @@ public class PostResponse {
     private final Long memberId;
     private final Long categoryId;
     private final LocalDateTime createdAt;
+    private final Double latitude;
+    private final Double longitude;
 
     public PostResponse(Post post) {
         this.id = post.getId();
@@ -30,10 +32,18 @@ public class PostResponse {
         this.memberId = post.getMember().getId();
         this.categoryId = post.getCategory() != null ? post.getCategory().getId() : null;
         this.createdAt = post.getCreatedAt();
+
+        if (post.getLocation() != null) {
+            this.latitude = post.getLocation().getLatitude();
+            this.longitude = post.getLocation().getLongitude();
+        } else {
+            this.latitude = null;
+            this.longitude = null;
+        }
     }
-    //  정적 팩토리 메서드 추가
+
+    // 정적 팩토리 메서드
     public static PostResponse from(Post post) {
         return new PostResponse(post);
     }
-
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #11 

## 📝작업 내용
- 사용자의 **GPS 좌표(위도, 경도)** 를 기준으로, **반경 3km 이내의 게시글**만 필터링하여 조회하는 기능입니다.
- 단순 키워드 기반 지역(예: "서울 송파구") 검색이 아니라, **실제 거리 기반 검색**을 통해 정밀한 지역 매칭이 가능합니다.
### 스크린샷 (선택)

