### PR TITLE
feat : 카테고리 조회 api

### DIFF
--- a/src/main/java/com/woong/daangnmarket/post/controller/SearchController.java
+++ b/src/main/java/com/woong/daangnmarket/post/controller/SearchController.java
@@ -1,0 +1,32 @@
+package com.woong.daangnmarket.post.controller;
+
+
+import com.woong.daangnmarket.post.dto.PostResponse;
+import com.woong.daangnmarket.post.service.PostServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final PostServiceImpl postServiceImpl;
+
+    @GetMapping("/category/{categoryId}")
+    public ResponseEntity<Page<PostResponse>> getPostsByCategory(
+            @PathVariable("categoryId") Long categoryId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        Page<PostResponse> posts = postServiceImpl.getPostsByCategory(categoryId, pageable);
+        return ResponseEntity.ok(posts);
+    }
+
+}
+
+

--- a/src/main/java/com/woong/daangnmarket/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/woong/daangnmarket/post/domain/repository/PostRepository.java
@@ -17,6 +17,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p WHERE p.id = :postId AND p.removed = false")
     public Optional<Post> findPostById(Long postId);
 
+    // 카테고리 ID로 게시글 검색 (페이징 처리 포함)
+    Page<Post> findByCategoryIdAndRemovedFalse(Long categoryId, Pageable pageable);
+
     // soft delete 처리된 게시글 제외하고 조회
     Page<Post> findAllByRemovedFalse(Pageable pageable);
     // 위치 기반 게시글 조회 - native query (반경 내 게시글 찾기)

--- a/src/main/java/com/woong/daangnmarket/post/service/PostServiceImpl.java
+++ b/src/main/java/com/woong/daangnmarket/post/service/PostServiceImpl.java
@@ -84,6 +84,13 @@ public class PostServiceImpl {
 
         return PostResponse.from(post);
     }
+    // ✅ 카테고리 기반 게시글 조회
+    @Transactional(readOnly = true)
+    public Page<PostResponse> getPostsByCategory(Long categoryId, Pageable pageable) {
+        return postRepository.findByCategoryIdAndRemovedFalse(categoryId, pageable)
+                .map(PostResponse::new);
+    }
+
     // 위치 기반 메서드 조회
     @Transactional(readOnly = true)
     public List<PostResponse> getPostsByLocation(double latitude, double longitude, double radius) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #13 

## 📝작업 내용
- 특정 카테고리에 속한 게시글을 조회할 수 있는 기능 추가

- 컨트롤러에서 /api/posts/category/{categoryId} 경로로 요청 시 해당 카테고리의 게시글 목록을 반환

- 서비스 레이어에서 PostRepository의 JPA 메서드를 통해 DB에서 조회

- PostResponse DTO로 게시글 데이터를 응답 형태로 변환



### 스크린샷 (선택)

