### PR TITLE
fix : `GET /api/posts/{id}` 요청 403 에러 수정 및 보안 설정 개선

### DIFF
--- a/src/main/java/com/woong/daangnmarket/config/SecurityConfig.java
+++ b/src/main/java/com/woong/daangnmarket/config/SecurityConfig.java
@@ -1,12 +1,13 @@
+
 package com.woong.daangnmarket.config;
 
 import com.woong.daangnmarket.jwt.JwtAuthenticationFilter;
 import com.woong.daangnmarket.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier; //
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -37,9 +38,13 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/members/**", "/api/login", "/api/signup" , "/api/logout" , "/api/posts/**", "/search/**").permitAll()
-                        .anyRequest().authenticated())
+                        .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()  // GET 요청만 인증 없이 허용
+                        .requestMatchers("/api/members/**", "/api/login", "/api/signup", "/api/logout", "/search/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+
                 .formLogin(form -> form.disable())
+
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/woong/daangnmarket/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/woong/daangnmarket/jwt/JwtAuthenticationFilter.java
@@ -28,16 +28,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String requestURI = request.getRequestURI();
         log.info("[JwtAuthenticationFilter] 요청 URI: {}", requestURI);
 
-        // 로그아웃 경로는 필터 통과시키기 (블랙리스트 검사 생략)
-        if (requestURI.equals("/api/logout")) {
-            log.info("[JwtAuthenticationFilter] 로그아웃 경로, 필터 통과");
-            filterChain.doFilter(request, response);
-            return;
-        }
-
         String token = resolveToken(request);
         log.info("[JwtAuthenticationFilter] 추출된 토큰: {}", token);
 
+        // 토큰이 존재하고 유효한 경우에만 인증 처리
         if (token != null && jwtTokenProvider.validateToken(token)) {
             log.info("[JwtAuthenticationFilter] 토큰 유효성 검사 통과");
 
@@ -53,7 +47,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(auth);
             log.info("[JwtAuthenticationFilter] 인증 정보 설정 완료: {}", auth.getName());
         } else {
-            log.info("[JwtAuthenticationFilter] 토큰이 없거나 유효하지 않음");
+            // 토큰이 없거나 유효하지 않은 경우, 인증 객체를 설정하지 않고 다음 필터로 진행
+            log.info("[JwtAuthenticationFilter] 토큰이 없거나 유효하지 않음 -> 인증 처리 스킵");
         }
 
         // 다음 필터로 진행
@@ -65,4 +60,3 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return (bearer != null && bearer.startsWith("Bearer ")) ? bearer.substring(7) : null;
     }
 }
-

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,5 +24,11 @@ jwt:
   secret: myVerySecretKeyThatIsAtLeast32BytesLong1234!
 
 redis:
-    host: localhost
-    port: 6379
+  host: localhost
+  port: 6379
+
+logging:
+  level:
+    org:
+      springframework:
+        security: DEBUG


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #8 

## 📝작업 내용

JwtAuthenticationFilter 로직 개선: 토큰이 존재할 때만 인증을 시도하도록 필터 로직을 수정하여 permitAll() 규칙이 온전히 적용되도록 개선했습니다.

SecurityConfig 규칙 순서 재정렬: 보안 규칙의 명확성을 위해 permitAll() 규칙을 anyRequest().authenticated()보다 먼저 배치했습니다.

요청 URL 수정: 테스트 과정에서 사용된 URL에서 특수 문자를 제거하여 HttpFirewall의 차단 없이 정상적으로 요청이 처리되도록 했습니다.
### 스크린샷 (선택)

