### PR TITLE
feat : 게시글 작성id와 회원id가 일치할시 수정이 가능한 api 구현

### DIFF
--- a/src/main/java/com/woong/daangnmarket/post/controller/PostController.java
+++ b/src/main/java/com/woong/daangnmarket/post/controller/PostController.java
@@ -55,6 +55,12 @@ public class PostController {
         PostResponse response = postService.updatePost(postId, request);
         return ResponseEntity.ok(response);
     }
+    // 게시글 삭제 api
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> deletePost(@PathVariable("postId") Long postId) {
+        postService.deletePost(postId);
+        return ResponseEntity.noContent().build();
+    }
 
 
     // 위치 기반 조회 api

--- a/src/main/java/com/woong/daangnmarket/post/controller/PostController.java
+++ b/src/main/java/com/woong/daangnmarket/post/controller/PostController.java
@@ -2,7 +2,8 @@ package com.woong.daangnmarket.post.controller;
 
 import com.woong.daangnmarket.post.dto.PostRequest;
 import com.woong.daangnmarket.post.dto.PostResponse;
-import com.woong.daangnmarket.post.service.PostServiceImpl;
+import com.woong.daangnmarket.post.dto.PostUpdateRequest;
+import com.woong.daangnmarket.post.service.PostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -19,7 +20,7 @@ import java.util.List;
 @RequestMapping("/api/posts")
 public class PostController {
 
-    private final PostServiceImpl postServiceImpl;
+    private final PostService postService;
 
 
     /**
@@ -30,22 +31,32 @@ public class PostController {
      */
     @PostMapping
     public ResponseEntity<PostResponse> createPost(@RequestBody @Valid PostRequest request) {
-        PostResponse response = postServiceImpl.createPost(request);
+        PostResponse response = postService.createPost(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
     // 게시글 전체 목록 조회 api
     @GetMapping
     public ResponseEntity<Page<PostResponse>> getAllPosts(Pageable pageable) {
-        Page<PostResponse> posts = postServiceImpl.getAllPosts(pageable);
+        Page<PostResponse> posts = postService.getAllPosts(pageable);
         return ResponseEntity.ok(posts);
     }
 
     // 특정 게시글 상세 조회 api
     @GetMapping("/{postId}")
     public ResponseEntity<PostResponse> getPostById(@PathVariable("postId") Long postId) {
-        PostResponse response = postServiceImpl.getPostById(postId);
+        PostResponse response = postService.getPostById(postId);
         return ResponseEntity.ok(response);
     }
+    // 게시글 수정 api
+    @PutMapping("/{postId}")
+    public ResponseEntity<PostResponse> updatePost(
+            @PathVariable("postId") Long postId,  // 여기서 이름 명시
+            @RequestBody PostUpdateRequest request) {
+        PostResponse response = postService.updatePost(postId, request);
+        return ResponseEntity.ok(response);
+    }
+
+
     // 위치 기반 조회 api
     @GetMapping("/search")
     public ResponseEntity<?> search(
@@ -53,7 +64,7 @@ public class PostController {
             @RequestParam("lon") double lon
     ) {
         // 예: 위도, 경도를 기반으로 5km 이내 게시글 조회
-        List<PostResponse> nearbyPosts = postServiceImpl.getPostsByLocation(lat, lon, 5.0); // 반경 5km
+        List<PostResponse> nearbyPosts = postService.getPostsByLocation(lat, lon, 5.0); // 반경 5km
 
         return ResponseEntity.ok(nearbyPosts);
     }

--- a/src/main/java/com/woong/daangnmarket/post/domain/entity/Location.java
+++ b/src/main/java/com/woong/daangnmarket/post/domain/entity/Location.java
@@ -27,4 +27,9 @@ public class Location {
         this.latitude = latitude;
         this.longitude = longitude;
     }
+    // 좌표 업데이트 메서드 추가
+    public void updateCoordinates(Double latitude, Double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
 }

--- a/src/main/java/com/woong/daangnmarket/post/domain/entity/Post.java
+++ b/src/main/java/com/woong/daangnmarket/post/domain/entity/Post.java
@@ -73,6 +73,18 @@ public class Post {
         this.location = location;
 
     }
+    public void updatePost(String title, String content, Integer price, String region,
+                           String status, String imageUrl, Category category, Location location) {
+        this.title = title;
+        this.content = content;
+        this.price = price;
+        this.region = region;
+        this.status = status;
+        this.imageUrl = imageUrl;
+        this.category = category;
+        this.location = location;
+    }
+
 
     /**
      * 게시글을 소프트 삭제 처리하는 메서드입니다.

--- a/src/main/java/com/woong/daangnmarket/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/woong/daangnmarket/post/domain/repository/PostRepository.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT p FROM Post p WHERE p.id = :postId AND p.removed = false")
-    public Optional<Post> findPostById(Long postId);
+    public Optional<Post> findPostById(@Param("postId") Long postId);
 
     // 카테고리 ID로 게시글 검색 (페이징 처리 포함)
     Page<Post> findByCategoryIdAndRemovedFalse(Long categoryId, Pageable pageable);

--- a/src/main/java/com/woong/daangnmarket/post/dto/PostUpdateRequest.java
+++ b/src/main/java/com/woong/daangnmarket/post/dto/PostUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.woong.daangnmarket.post.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PostUpdateRequest {
+
+    private String title;
+    private String content;
+    private Integer price;
+    private String region;
+    private String status;
+    private String imageUrl;
+    private Long categoryId;
+    private Double latitude;
+    private Double longitude;
+}

--- a/src/main/java/com/woong/daangnmarket/post/service/PostService.java
+++ b/src/main/java/com/woong/daangnmarket/post/service/PostService.java
@@ -20,6 +20,7 @@ public interface PostService {
 
     List<PostResponse> getPostsByLocation(double latitude, double longitude, double radius);
 
+    void deletePost(Long postId);
 
 
 

--- a/src/main/java/com/woong/daangnmarket/post/service/PostService.java
+++ b/src/main/java/com/woong/daangnmarket/post/service/PostService.java
@@ -2,13 +2,25 @@ package com.woong.daangnmarket.post.service;
 
 import com.woong.daangnmarket.post.dto.PostRequest;
 import com.woong.daangnmarket.post.dto.PostResponse;
+import com.woong.daangnmarket.post.dto.PostUpdateRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface PostService {
 
     PostResponse createPost(PostRequest request);
 
     Page<PostResponse> getAllPosts(Pageable pageable);
+
+    PostResponse updatePost(Long postId, PostUpdateRequest request);
+
+    PostResponse getPostById(Long postId);
+
+    List<PostResponse> getPostsByLocation(double latitude, double longitude, double radius);
+
+
+
 
 }

--- a/src/main/java/com/woong/daangnmarket/post/service/PostServiceImpl.java
+++ b/src/main/java/com/woong/daangnmarket/post/service/PostServiceImpl.java
@@ -12,10 +12,13 @@ import com.woong.daangnmarket.post.domain.repository.PostRepository;
 import com.woong.daangnmarket.post.dto.PostRequest;
 import com.woong.daangnmarket.post.dto.PostResponse;
 
+import com.woong.daangnmarket.post.dto.PostUpdateRequest;
 import com.woong.daangnmarket.post.exception.PostNotFoundException;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,11 +26,12 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class PostServiceImpl {
+public class PostServiceImpl implements PostService {
 
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
+
 
     @Transactional
     public PostResponse createPost(PostRequest request) {
@@ -76,6 +80,7 @@ public class PostServiceImpl {
         return postRepository.findAllByRemovedFalse(pageable)
                 .map(PostResponse::new);
     }
+
     // 특정 게시글 조회
     @Transactional(readOnly = true)
     public PostResponse getPostById(Long postId) {
@@ -84,11 +89,64 @@ public class PostServiceImpl {
 
         return PostResponse.from(post);
     }
-    // ✅ 카테고리 기반 게시글 조회
+
+    // 카테고리 기반 게시글 조회
     @Transactional(readOnly = true)
     public Page<PostResponse> getPostsByCategory(Long categoryId, Pageable pageable) {
         return postRepository.findByCategoryIdAndRemovedFalse(categoryId, pageable)
                 .map(PostResponse::new);
+    }
+    // 게시글 수정
+    @Transactional
+    public PostResponse updatePost(Long postId, PostUpdateRequest request) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
+
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        String currentUserEmail;
+
+        if (principal instanceof org.springframework.security.core.userdetails.UserDetails) {
+            currentUserEmail = ((org.springframework.security.core.userdetails.UserDetails) principal).getUsername();
+        } else if (principal instanceof String) {
+            currentUserEmail = (String) principal;  // 일반적으로 "anonymousUser"일 수도 있음
+        } else {
+            currentUserEmail = null;  // 예상치 못한 타입 처리
+        }
+
+        System.out.println("현재 인증된 사용자 이메일: " + currentUserEmail);
+
+
+
+        // 작성자인지 확인
+        Member member = post.getMember();
+        if (!member.getEmail().equals(currentUserEmail)) {
+            throw new SecurityException("게시글 작성자만 수정할 수 있습니다.");
+        }
+
+        // 카테고리 조회 (Optional)
+        var category = request.getCategoryId() != null ?
+                categoryRepository.findById(request.getCategoryId()).orElse(null) : null;
+
+        // Location 업데이트 (Optional)
+        Location location = post.getLocation();
+        if (location != null && request.getLatitude() != null && request.getLongitude() != null) {
+            location.updateCoordinates(request.getLatitude(), request.getLongitude());
+        }
+
+        // 게시글 정보 업데이트
+        post.updatePost(
+                request.getTitle(),
+                request.getContent(),
+                request.getPrice(),
+                request.getRegion(),
+                request.getStatus(),
+                request.getImageUrl(),
+                category,
+                location
+        );
+
+        return PostResponse.from(post);
     }
 
     // 위치 기반 메서드 조회
@@ -99,5 +157,6 @@ public class PostServiceImpl {
                 .map(PostResponse::new)
                 .toList();
     }
+
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #15 

## 📝작업 내용

1. **게시글 수정 시 인증된 사용자와 게시글 작성자 일치 여부 검증**
   - `SecurityContextHolder.getContext().getAuthentication().getPrincipal()`로 현재 로그인한 사용자 이메일 조회.
   - 게시글의 작성자(Member) 이메일과 비교하여 일치하지 않으면 `SecurityException` 발생.
   - 인증에 성공하면 게시글을 수정하도록 로직 구성.

2. **JwtAuthenticationFilter에서 SecurityContextHolder 설정**
   - JWT를 통해 사용자 이메일을 추출하고, 인증 객체(Authentication)를 SecurityContextHolder에 설정.
   - Redis를 통한 블랙리스트(로그아웃 처리된 토큰) 검증 로직 포함.

3. **Service 계층 Interface-Impl 구조 리팩토링**
   - `PostService` 인터페이스 생성 (게시글 서비스의 역할 정의)
   - `PostServiceImpl` 클래스에서 `PostService` 인터페이스 구현.
   - Controller는 `PostService`를 의존하도록 변경하여 느슨한 결합 구조로 개선.
   - 향후 테스트 및 유지보수에 용이하도록 레이어 구조를 명확히 분리.

4. **Controller 계층 리팩토링**
   - `PostController`에서 서비스 계층 메서드 호출 방식 정리.
   - 인증 정보 및 파라미터 전달 방식 일관성 있게 개선.

5. **테스트 데이터 정비**
   - 게시글(Post)의 `member_id`가 로그인한 사용자의 `member_id`와 일치하지 않아 발생한 권한 예외를 수정.
   - 테스트 데이터에서 게시글 작성자의 `member_id`를 로그인 사용자와 동일하게 맞춰 정상 수정 동작 확인.

### 테스트
- Postman을 이용해 게시글 수정 API 테스트
  - 작성자가 본인인 경우 게시글 수정 성공.
  - 작성자가 아닌 경우 `게시글 작성자만 수정할 수 있습니다.` 예외 발생.

### 스크린샷 (선택)

