### PR TITLE
feat: 게시글 등록 API에 이미지 업로드 기능 추가 및 S3 연동 구현

### DIFF
--- a/src/main/java/com/woong/daangnmarket/post/controller/PostController.java
+++ b/src/main/java/com/woong/daangnmarket/post/controller/PostController.java
@@ -11,7 +11,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 
@@ -29,11 +31,16 @@ public class PostController {
      * @param request 게시글 등록 요청 데이터
      * @return 생성된 게시글 정보(PostResponse)
      */
+    // 게시글 생성
     @PostMapping
-    public ResponseEntity<PostResponse> createPost(@RequestBody @Valid PostRequest request) {
-        PostResponse response = postService.createPost(request);
+    public ResponseEntity<PostResponse> createPost(
+            @RequestPart("post") @Valid PostRequest request,
+            @RequestPart(value = "image", required = false) MultipartFile imageFile) throws IOException {
+
+        PostResponse response = postService.createPost(request, imageFile);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
+
     // 게시글 전체 목록 조회 api
     @GetMapping
     public ResponseEntity<Page<PostResponse>> getAllPosts(Pageable pageable) {

--- a/src/main/java/com/woong/daangnmarket/post/service/PostService.java
+++ b/src/main/java/com/woong/daangnmarket/post/service/PostService.java
@@ -5,12 +5,14 @@ import com.woong.daangnmarket.post.dto.PostResponse;
 import com.woong.daangnmarket.post.dto.PostUpdateRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 public interface PostService {
 
-    PostResponse createPost(PostRequest request);
+    PostResponse createPost(PostRequest request, MultipartFile imageFile) throws IOException;
 
     Page<PostResponse> getAllPosts(Pageable pageable);
 

--- a/src/main/java/com/woong/daangnmarket/post/service/PostServiceImpl.java
+++ b/src/main/java/com/woong/daangnmarket/post/service/PostServiceImpl.java
@@ -1,6 +1,7 @@
 package com.woong.daangnmarket.post.service;
 
 
+import com.woong.daangnmarket.image.service.ImageService;
 import com.woong.daangnmarket.member.domain.Member;
 
 import com.woong.daangnmarket.member.domain.repository.MemberRepository;
@@ -21,7 +22,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @Service
@@ -31,10 +34,16 @@ public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
+    private final ImageService imageService;
 
 
     @Transactional
-    public PostResponse createPost(PostRequest request) {
+    public PostResponse createPost(PostRequest request, MultipartFile imageFile) throws IOException {
+        String imageUrl = null;
+        if (imageFile != null && !imageFile.isEmpty()) {
+            imageUrl = imageService.uploadImage(imageFile);
+        }
+
         // 작성자 조회
         Member member = memberRepository.findById(request.getMemberId())
                 .orElseThrow(() -> new IllegalArgumentException("작성자 정보가 존재하지 않습니다."));
@@ -62,7 +71,7 @@ public class PostServiceImpl implements PostService {
                 .price(request.getPrice())
                 .region(request.getRegion())
                 .status(request.getStatus())
-                .imageUrl(request.getImageUrl())
+                .imageUrl(imageUrl)  // 요청에서 받은 URL 대신 S3 업로드 URL 사용
                 .location(location)
                 .member(member)
                 .category(category)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #18 

## 📝작업 내용

- 이미지 업로드를 위한 S3Uploader 유틸 클래스 구현

- 이미지 업로드 API 추가 (/api/images)

- 게시글 등록 API에서 Multipart 요청 처리하도록 변경

- 게시글 등록 시 이미지 파일이 있으면 S3에 업로드 후 URL을 게시글에 저장하도록 서비스 로직 개선

- 포스트맨 테스트 완료 및 정상 동작 확인

- Spring Security JWT 인증 적용 상태에서 이미지 업로드 및 게시글 등록 가능하도록 처리

### 스크린샷 (선택)

