### PR TITLE
feat: 채팅 도메인 및 레포지토리 기본 구조 추가

### DIFF
--- a/src/main/java/com/woong/daangnmarket/chat/domain/ChatMessage.java
+++ b/src/main/java/com/woong/daangnmarket/chat/domain/ChatMessage.java
@@ -1,0 +1,33 @@
+package com.woong.daangnmarket.chat.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 메시지 내용
+    @Column(nullable = false)
+    private String message;
+
+    // 발신자 (User ID)
+    private Long senderId;
+
+    // 보낸 시간
+    private LocalDateTime sentAt;
+
+    // 어떤 채팅방의 메시지인지
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+}

--- a/src/main/java/com/woong/daangnmarket/chat/domain/ChatRoom.java
+++ b/src/main/java/com/woong/daangnmarket/chat/domain/ChatRoom.java
@@ -1,0 +1,26 @@
+package com.woong.daangnmarket.chat.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 게시글 ID (어떤 상품 채팅인지 구분)
+    private Long postId;
+
+    // 판매자 ID
+    private Long sellerId;
+
+    // 구매자 ID
+    private Long buyerId;
+}

--- a/src/main/java/com/woong/daangnmarket/chat/respository/ChatMessageRepository.java
+++ b/src/main/java/com/woong/daangnmarket/chat/respository/ChatMessageRepository.java
@@ -1,0 +1,12 @@
+package com.woong.daangnmarket.chat.respository;
+
+import com.woong.daangnmarket.chat.domain.ChatMessage;
+import com.woong.daangnmarket.chat.domain.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    // 특정 채팅방의 모든 메시지 조회
+    List<ChatMessage> findByChatRoom(ChatRoom chatRoom);
+}

--- a/src/main/java/com/woong/daangnmarket/chat/respository/ChatRoomRepository.java
+++ b/src/main/java/com/woong/daangnmarket/chat/respository/ChatRoomRepository.java
@@ -1,0 +1,9 @@
+package com.woong.daangnmarket.chat.respository;
+
+import com.woong.daangnmarket.chat.domain.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    // 필요 시: 특정 게시글+구매자+판매자로 채팅방 찾기
+    ChatRoom findByPostIdAndBuyerIdAndSellerId(Long postId, Long buyerId, Long sellerId);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #22 

## 📝작업 내용

- ChatRoom 엔티티 생성
  - 게시글, 판매자, 구매자 매핑 필드 추가
- ChatMessage 엔티티 생성
  - 메시지 내용, 발신자, 채팅방, 시간 저장
- ChatRoomRepository, ChatMessageRepository 생성
  - 채팅방 조회 및 메시지 조회 기능 추가

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

