### PR TITLE
feat:  WebSocket 및 STOMP 기본 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis' // redis
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE' //s3uploader
+	implementation 'org.springframework.boot:spring-boot-starter-websocket' // websocket
 	// JWT 최신 버전 (0.11.5)으로 교체
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/woong/daangnmarket/config/SecurityConfig.java
+++ b/src/main/java/com/woong/daangnmarket/config/SecurityConfig.java
@@ -38,10 +38,12 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()  // GET 요청만 인증 없이 허용
-                        .requestMatchers("/api/members/**", "/api/login", "/api/signup", "/api/logout", "/search/**").permitAll()
+                        .requestMatchers("/ws/**").permitAll() // WebSocket 전체 경로 인증 제외
+                        .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
+                        .requestMatchers("/api/members/**", "/api/login", "/api/signup", "/api/logout", "/search/**","/api/images").permitAll()
                         .anyRequest().authenticated()
                 )
+
 
                 .formLogin(form -> form.disable())
 

--- a/src/main/java/com/woong/daangnmarket/config/WebSocketConfig.java
+++ b/src/main/java/com/woong/daangnmarket/config/WebSocketConfig.java
@@ -1,0 +1,28 @@
+package com.woong.daangnmarket.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker // STOMP 기반 WebSocket 메시지 브로커 활성화
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // 클라이언트에서 ws://localhost:8080/ws 로 연결
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*"); // CORS 허용
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 구독(Subscribe) prefix → /topic
+        registry.enableSimpleBroker("/topic");
+
+        // 발행(Publish) prefix → /app
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #22 

## 📝작업 내용
websocket 의존성 추가.
websocket 경로제한없이 허용.
 실시간 채팅 기능을 위해 STOMP 프로토콜 기반의 WebSocket 연동에 필요한 기본 설정을 추가합니다.

   클라이언트는 /ws 엔드포인트를 통해 서버에 연결할 수 있으며, 메시지 발행은 /app 접두사를, 구독은 /topic 접두사를 사용하도록 메시지 브로커를  설정했습니다.


### 스크린샷 (선택)

