### PR TITLE
feat:   WebSocket 기반 실시간 채팅 기능 구현

### DIFF
--- a/src/main/java/com/woong/daangnmarket/chat/controller/ChatStompController.java
+++ b/src/main/java/com/woong/daangnmarket/chat/controller/ChatStompController.java
@@ -1,0 +1,26 @@
+package com.woong.daangnmarket.chat.controller;
+
+
+import com.woong.daangnmarket.chat.domain.ChatMessage;
+import com.woong.daangnmarket.chat.dto.ChatMessageDto;
+import com.woong.daangnmarket.chat.service.ChatMessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatStompController {
+
+    private final ChatMessageService chatMessageService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/chat.send/{roomId}")
+    public void sendMessage(@DestinationVariable Long roomId, ChatMessageDto dto) {
+         chatMessageService.saveMessage(dto);
+
+    }
+}
+

--- a/src/main/java/com/woong/daangnmarket/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/woong/daangnmarket/chat/dto/ChatMessageDto.java
@@ -1,0 +1,14 @@
+package com.woong.daangnmarket.chat.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageDto {
+
+    private long roomId;
+    private long senderId;     // 발신자 (username, userId 등)
+    private String message;    // 메시지 내용
+    private String timestamp;  // 보낸 시간
+}

--- a/src/main/java/com/woong/daangnmarket/chat/service/ChatMessageService.java
+++ b/src/main/java/com/woong/daangnmarket/chat/service/ChatMessageService.java
@@ -1,0 +1,43 @@
+package com.woong.daangnmarket.chat.service;
+
+import com.woong.daangnmarket.chat.domain.ChatMessage;
+import com.woong.daangnmarket.chat.domain.ChatRoom;
+import com.woong.daangnmarket.chat.dto.ChatMessageDto;
+import com.woong.daangnmarket.chat.respository.ChatMessageRepository;
+import com.woong.daangnmarket.chat.respository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public ChatMessage saveMessage(ChatMessageDto dto) {
+        ChatRoom room = chatRoomRepository.findById(dto.getRoomId())
+                .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
+
+        ChatMessage message = ChatMessage.builder()
+                .chatRoom(room)
+                .senderId(dto.getSenderId())
+                .message(dto.getMessage())
+                .sentAt(LocalDateTime.now())
+                .build();
+
+        ChatMessage savedMessage = chatMessageRepository.save(message);
+
+        // 저장된 메시지를 구독자에게 브로드캐스트
+        messagingTemplate.convertAndSend(
+                "/topic/chat/" + dto.getRoomId(),
+                dto
+        );
+
+        return savedMessage;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #22 

## 📝작업 내용
 STOMP 프로토콜 기반의 WebSocket 설정을 추가하고, 채팅 메시지(ChatMessage)와 채팅방(ChatRoom) 도메인을 설계했습니다. 또한, 클라이언트의  메시지를 받아 DB에 저장하고 모든 구독자에게 전송하는 컨트롤러와 서비스 로직을 구현했습니다.

 - [x] STOMP 엔드포인트(/ws) 및 메시지 브로커 Prefix 설정
 - [x] ChatMessage, ChatRoom 엔티티 클래스 생성
 - [x] ChatStompController 추가 및 /app/chat.send/{roomId} 핸들러 구현
 - [x] ChatMessageService에 메시지 저장 및 브로드캐스트 로직 구현
 - [x] Controller와 Service에서 중복으로 메시지를 전송하던 문제 수정


### 스크린샷 (선택)

